### PR TITLE
Update URL and description for AddThis Analytics

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -30,5 +30,5 @@
 	<!-- AddThis grid keys (only a few, since the grid does very little) -->
 	<message key="plugins.generic.addThis.grid.shares">Geteilt</message>
 	<message key="plugins.generic.addThis.grid.title">Am häufigsten geteilte Links</message>
-	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Diese Liste zeigt Ihre populärsten geteilte Links der letzten Woche. Für alle möglichen AddThis-Statistiken besuchen Sie bitte die <a href="http://www.addthis.com/analytics" target="_blank">AddThis-Analytics</a>-Website und loggen Sie sich dort ein.]]></message>
+	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Diese Liste zeigt Ihre populärsten geteilte Links der letzten Woche. Für alle möglichen AddThis-Statistiken besuchen Sie bitte die <a href="https://www.addthis.com/dashboard" target="_blank">AddThis-Dashboard</a>-Website und loggen Sie sich dort ein.]]></message>
 </locale>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -30,5 +30,5 @@
 	<!-- AddThis grid keys (only a few, since the grid does very little) -->
 	<message key="plugins.generic.addThis.grid.shares">Shares</message>
 	<message key="plugins.generic.addThis.grid.title">Top Shared Links</message>
-	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[This list shows your most popular shared links for the past week. For all of the possible AddThis statistics, please visit the <a href="http://www.addthis.com/analytics" target="_blank">AddThis Analytics</a> website and log in.]]></message>
+	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[This list shows your most popular shared links for the past week. For all of the possible AddThis statistics, please visit the <a href="https://www.addthis.com/dashboard" target="_blank">AddThis Dashboard</a> website and log in.]]></message>
 </locale>

--- a/locale/es_ES/locale.xml
+++ b/locale/es_ES/locale.xml
@@ -30,5 +30,5 @@
 	<!-- AddThis grid keys (only a few, since the grid does very little) -->
 	<message key="plugins.generic.addThis.grid.shares">Compartidos</message>
 	<message key="plugins.generic.addThis.grid.title">Enlaces más compartidos</message>
-	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Esta lista muestra los enlaces más compartidos durante la última semana. Para visualizar todas las estadísticas de AddThis, visite el sitio web <a href="http://www.addthis.com/analytics" target="_blank">AddThis Analytics</a> e inicie sesión.]]></message>
+	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Esta lista muestra los enlaces más compartidos durante la última semana. Para visualizar todas las estadísticas de AddThis, visite el sitio web <a href="https://www.addthis.com/dashboard" target="_blank">AddThis Dashboard</a> e inicie sesión.]]></message>
 </locale>

--- a/locale/fi_FI/locale.xml
+++ b/locale/fi_FI/locale.xml
@@ -30,5 +30,5 @@
 	<!-- AddThis grid keys (only a few, since the grid does very little) -->
 	<message key="plugins.generic.addThis.grid.shares">Jaot</message>
 	<message key="plugins.generic.addThis.grid.title">Eniten jaettu</message>
-	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Tämä lista näyttää kuluneen viikon eniten jaetut linkit. Koko statistiikka näkyy <a href="http://www.addthis.com/analytics" target="_blank">AddThis Analytics</a> sivustolla. Kirjaudu omilla tunnuksillasi.]]></message>
+	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Tämä lista näyttää kuluneen viikon eniten jaetut linkit. Koko statistiikka näkyy <a href="https://www.addthis.com/dashboard" target="_blank">AddThis Dashboard</a> sivustolla. Kirjaudu omilla tunnuksillasi.]]></message>
 </locale>

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -12,7 +12,7 @@
   -->
 
 <locale name="pt_PT" full_name="Português (Portugal)">
-	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Esta lista apresenta os trabalhos mais partilhados da semana passada. Para obter todas as estatísticas, visite  o website <a href="http://www.addthis.com/analytics" target="_blank">AddThis Analytics</a> e inicie sessão.]]></message>
+	<message key="plugins.generic.addThis.statistics.instructions"><![CDATA[Esta lista apresenta os trabalhos mais partilhados da semana passada. Para obter todas as estatísticas, visite  o website <a href="https://www.addthis.com/dashboard" target="_blank">AddThis Dashboard</a> e inicie sessão.]]></message>
 	<message key="plugins.generic.addThis.grid.shares">Partilhas</message>
 	<message key="plugins.generic.addThis.grid.title">Links mais partilhados</message>
 	<message key="plugins.generic.addThis.form.registerLink"><![CDATA[<a href="https://www.addthis.com/register">Registe-se</a> gratuitamente para obter relatórios detalhados e perceber o comportamento dos trabalhos na web social.]]></message>


### PR DESCRIPTION
According to the vendor's information on the old URL,
Analytics has moved. It is now AddThis Dashboard.

Signed-off-by: Stefan Weil <sw@weilnetz.de>