### PR TITLE
Smarty error in /assign tag

### DIFF
--- a/templates/statistics.tpl
+++ b/templates/statistics.tpl
@@ -16,7 +16,7 @@
 <p>{translate key="plugins.generic.addThis.statistics.instructions"}</p>
 
 <form class="pkp_form" id="statisticsDisplayForm">
-	{capture assign="addThisStatisticsGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="plugins.generic.addThis.controllers.grid.AddThisStatisticsGridHandler" op="fetchGrid" escape=false}{/assign}
+	{capture assign="addThisStatisticsGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="plugins.generic.addThis.controllers.grid.AddThisStatisticsGridHandler" op="fetchGrid" escape=false}{/capture}
 	{load_url_in_div id="addThisStatisticsGridContainer" url=$addThisStatisticsGridUrl}
 	{fbvElement type="button" id="cancelFormButton" label="common.close"}
 </form>


### PR DESCRIPTION
There was an error in the statistics.tpl file, when closing the capture tag with /asign instead of /capture